### PR TITLE
Add new rule on import sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add new import order to be more strictly
+
 ## v3.0.0 - 2020-03-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
+### BREAKING CHANGES
 
 - Add new import order to be more strictly
 

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -255,11 +255,7 @@
       "groups": [
         ["builtin", "external"]
       ],
-      "newlines-between": "always",
-      "alphabetize": {
-        "order": "asc",
-        "caseInsensitive": true
-      }
+      "newlines-between": "always"
     }],
     "symbol-description": "error",
     "template-curly-spacing": "error",

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -250,7 +250,17 @@
     "prefer-template": "error",
     "require-yield": "error",
     "rest-spread-spacing": "error",
-    "sort-imports": "error",
+    "sort-imports": 0,
+    "import/order": ["error", {
+      "groups": [
+        ["builtin", "external"]
+      ],
+      "newlines-between": "always",
+      "alphabetize": {
+        "order": "asc",
+        "caseInsensitive": true
+      }
+    }],
     "symbol-description": "error",
     "template-curly-spacing": "error",
     "yield-star-spacing": "error"

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "unit": "tap --no-esm -b -o tap.log tests/*.test.js",
     "version": "./scripts/update-version.sh ${npm_package_version} && git add CHANGELOG.md"
   },
-  "dependencies": {},
   "devDependencies": {
     "eslint": "^6.8.0",
     "tap": "^14.10.6"
   },
   "peerDependencies": {
-    "eslint": ">=6.8.0"
+    "eslint": ">=6.8.0",
+    "eslint-plugin-import": ">=2.0.0"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
This rule is high opinionated. We could set in a different lint plugin.

Another lint to add could be a lint for react app for example, since it is quite different from the actual. 

We have 2 possibilities:
* add the additional peer dependencies and document it based on the used lint rule
* create a monorepo with different linter, each with the correct peer deps