### PR TITLE
fixed rule for double empty lines

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -181,7 +181,12 @@
     "no-mixed-operators": "error",
     "no-mixed-spaces-and-tabs": "error",
     "no-multi-assign": "error",
-    "no-multiple-empty-lines": "error",
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1
+      }
+    ],
     "no-nested-ternary": "error",
     "no-new-object": "error",
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],


### PR DESCRIPTION
`no-multiple-empty-lines` defaults to: `max: 2`  
https://eslint.org/docs/latest/rules/no-multiple-empty-lines#options

before (this was ok):  
```js
const myVar = ""


const myOtherVar = ""
```


after (results in error):  
```js
const myVar = ""


const myOtherVar = ""
```